### PR TITLE
Use ffmpeg instead of libav in python ver

### DIFF
--- a/pulverize.py
+++ b/pulverize.py
@@ -102,7 +102,7 @@ def render_proc(args, start_frame, end_frame, outdir):
 
 def join_chunks(args, outdir):
     """
-    Concatenate the video chunks together with avconv
+    Concatenate the video chunks together with ffmpeg
     """
     # Which files do we need to join?
     chunk_files = sorted(glob.glob(os.path.join(outdir, 'pulverize_frames_*')))
@@ -116,11 +116,11 @@ def join_chunks(args, outdir):
     outbase, outext = os.path.splitext(os.path.basename(chunk_files[0]))
     outfile = '%s%s' % (filebase, outext)
     log.info("Joining parts into: %s", outfile)
-    params = ['avconv', '-stats', '-f', 'concat',
+    params = ['ffmpeg', '-stats', '-f', 'concat',
             '-safe', '0',
             '-i', file_list,
             '-c', 'copy', outfile]
-    log.debug("avconv params: %s", params)
+    log.debug("ffmpeg params: %s", params)
     if not args.dry_run:
         subprocess.check_call(params)
 


### PR DESCRIPTION
This commit changes the concatenate parameter from `avconv` to `ffmpeg`
As pulverize.php uses ffmpeg as default, rather than its fork libav.

Fixes #5 

Seems some older Ubuntu/Debian versions used libav and now symlink ffmpeg for compability reasons https://stackoverflow.com/a/9477756