### PR TITLE
Fix audio pauses

### DIFF
--- a/pulverize.py
+++ b/pulverize.py
@@ -25,8 +25,8 @@ def get_project_data(args):
     
     realpath = os.path.dirname(os.path.realpath(__file__))
     utilfile = os.path.join(realpath, UTIL_SCRIPT)
-    data = subprocess.check_output(['blender', '-b', args.blendfile, '-P', utilfile])
-    
+    data = subprocess.check_output(['blender', '-b', args.blendfile, '-P', utilfile]).decode("utf-8")
+
     lines = data.split('\n')
     frameinfo = lines[0].split()
     # log.debug("frameinfo: %s", frameinfo)
@@ -76,7 +76,7 @@ def render_chunks(args, frame_start, frame_end, outdir):
         log.info("Started render process %d with pid %d", i, p.pid)
         pass
 
-    
+
     # wait for results
     for i, p in enumerate(processes):
         log.debug("Waiting for proc %d", i)
@@ -88,7 +88,7 @@ def render_proc(args, start_frame, end_frame, outdir):
     """
     Render a chunk of the blender file.
     """
-    outfilepath = '%spulverize_frames_#######' % outdir
+    outfilepath = '%s%spulverize_frames_#######' % (outdir, os.sep)
     params = ['blender', '-b', args.blendfile,
                           '-s', '%s' % start_frame,
                           '-e', '%s' % end_frame,

--- a/pulverize.py
+++ b/pulverize.py
@@ -76,7 +76,7 @@ def render_chunks(args, frame_start, frame_end, outdir, utilfile):
         p = multiprocessing.Process(target=render_proc, args=(args, w_start_frame, w_end_frame, outdir))
         processes.append(p)
         p.start()
-        log.info("Started video render process %d with pid %d", ++i, p.pid)
+        log.info("Started video render process %d with pid %d", i, p.pid)
         pass
 
     # Set a worker to work on the audio

--- a/pulverize_tool.py
+++ b/pulverize_tool.py
@@ -1,5 +1,16 @@
 import bpy
-
 scene = bpy.context.scene
-print("FRAMES: %d %d" % (scene.frame_start, scene.frame_end))
-print("OUTPUTDIR: %s" % (scene.render.filepath))
+
+
+def get_scene_data():
+    print("FRAMES: %d %d" % (scene.frame_start, scene.frame_end))
+    print("OUTPUTDIR: %s" % (scene.render.filepath))
+
+
+def set_audio_only():
+    sed = scene.sequence_editor
+    sequences = sed.sequences_all
+
+    for strip in sequences:
+        if strip.type != "SOUND":
+            strip.mute = True

--- a/pulverize_tool.py
+++ b/pulverize_tool.py
@@ -14,3 +14,7 @@ def set_audio_only():
     for strip in sequences:
         if strip.type != "SOUND":
             strip.mute = True
+
+
+def mixdown(filepath):
+    bpy.ops.sound.mixdown(filepath=filepath, check_existing=False, relative_path=False, container="FLAC", codec="FLAC")


### PR DESCRIPTION
This will resolve the audio skips by rendering a separate audio-only track on a single thread, then joining that to the usual output of pulverize with ffmpeg.

This also allows use of code in pulverize_tools in a programmatic way, so interfacing with blender is a bit easier.